### PR TITLE
Add day and week navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # Ignore Gradle build output directory
 build
+
+venv
+*.ipynb
+*.py

--- a/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.form
+++ b/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.form
@@ -61,6 +61,82 @@
 
               <Layout class="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout"/>
               <SubComponents>
+                <Container class="javax.swing.JPanel" name="WeeklyPanel">
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
+                      <JTabbedPaneConstraints tabName="Weekly">
+                        <Property name="tabTitle" type="java.lang.String" value="Weekly"/>
+                      </JTabbedPaneConstraints>
+                    </Constraint>
+                  </Constraints>
+
+                  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
+                    <Property name="axis" type="int" value="1"/>
+                  </Layout>
+                  <SubComponents>
+                    <Container class="javax.swing.JPanel" name="weeklyChartPanel">
+                      <Properties>
+                        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+                          <Border info="org.netbeans.modules.form.compat2.border.SoftBevelBorderInfo">
+                            <BevelBorder/>
+                          </Border>
+                        </Property>
+                      </Properties>
+
+                      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout">
+                        <Property name="horizontalGap" type="int" value="10"/>
+                        <Property name="verticalGap" type="int" value="10"/>
+                      </Layout>
+                    </Container>
+                    <Container class="javax.swing.JPanel" name="WeeksTitlePanel">
+                      <Properties>
+                        <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                          <Font name="Segoe UI" size="12" style="1"/>
+                        </Property>
+                      </Properties>
+
+                      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+                      <SubComponents>
+                        <Component class="javax.swing.JLabel" name="weeksLabel">
+                          <Properties>
+                            <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                              <Font name="Segoe UI Semibold" size="18" style="1"/>
+                            </Property>
+                            <Property name="text" type="java.lang.String" value="7 March - 14 March"/>
+                          </Properties>
+                        </Component>
+                      </SubComponents>
+                    </Container>
+                    <Container class="javax.swing.JPanel" name="ActionButtonPanel">
+
+                      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+                      <SubComponents>
+                        <Component class="javax.swing.JButton" name="PreviousWeeksbtn">
+                          <Properties>
+                            <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                              <Font name="Segoe UI" size="12" style="1"/>
+                            </Property>
+                            <Property name="text" type="java.lang.String" value="Previous Week"/>
+                          </Properties>
+                          <Events>
+                            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="PreviousWeeksbtnActionPerformed"/>
+                          </Events>
+                        </Component>
+                        <Component class="javax.swing.JButton" name="NextWeeksbtn">
+                          <Properties>
+                            <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                              <Font name="Segoe UI" size="12" style="1"/>
+                            </Property>
+                            <Property name="text" type="java.lang.String" value="Next Week"/>
+                          </Properties>
+                          <Events>
+                            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="NextWeeksbtnActionPerformed"/>
+                          </Events>
+                        </Component>
+                      </SubComponents>
+                    </Container>
+                  </SubComponents>
+                </Container>
                 <Container class="javax.swing.JPanel" name="DailyPanel">
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
@@ -150,82 +226,6 @@
                             </Property>
                             <Property name="text" type="java.lang.String" value="Next Day"/>
                           </Properties>
-                        </Component>
-                      </SubComponents>
-                    </Container>
-                  </SubComponents>
-                </Container>
-                <Container class="javax.swing.JPanel" name="WeeklyPanel">
-                  <Constraints>
-                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
-                      <JTabbedPaneConstraints tabName="Weekly">
-                        <Property name="tabTitle" type="java.lang.String" value="Weekly"/>
-                      </JTabbedPaneConstraints>
-                    </Constraint>
-                  </Constraints>
-
-                  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
-                    <Property name="axis" type="int" value="1"/>
-                  </Layout>
-                  <SubComponents>
-                    <Container class="javax.swing.JPanel" name="weeklyChartPanel">
-                      <Properties>
-                        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
-                          <Border info="org.netbeans.modules.form.compat2.border.SoftBevelBorderInfo">
-                            <BevelBorder/>
-                          </Border>
-                        </Property>
-                      </Properties>
-
-                      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout">
-                        <Property name="horizontalGap" type="int" value="10"/>
-                        <Property name="verticalGap" type="int" value="10"/>
-                      </Layout>
-                    </Container>
-                    <Container class="javax.swing.JPanel" name="WeeksTitlePanel">
-                      <Properties>
-                        <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
-                          <Font name="Segoe UI" size="12" style="1"/>
-                        </Property>
-                      </Properties>
-
-                      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
-                      <SubComponents>
-                        <Component class="javax.swing.JLabel" name="weeksLabel">
-                          <Properties>
-                            <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
-                              <Font name="Segoe UI Semibold" size="18" style="1"/>
-                            </Property>
-                            <Property name="text" type="java.lang.String" value="7 March - 14 March"/>
-                          </Properties>
-                        </Component>
-                      </SubComponents>
-                    </Container>
-                    <Container class="javax.swing.JPanel" name="ActionButtonPanel">
-
-                      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
-                      <SubComponents>
-                        <Component class="javax.swing.JButton" name="PreviousWeeksbtn">
-                          <Properties>
-                            <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
-                              <Font name="Segoe UI" size="12" style="1"/>
-                            </Property>
-                            <Property name="text" type="java.lang.String" value="Previous Week"/>
-                          </Properties>
-                          <Events>
-                            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="PreviousWeeksbtnActionPerformed"/>
-                          </Events>
-                        </Component>
-                        <Component class="javax.swing.JButton" name="NextWeeksbtn">
-                          <Properties>
-                            <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
-                              <Font name="Segoe UI" size="12" style="1"/>
-                            </Property>
-                            <Property name="text" type="java.lang.String" value="Next Week"/>
-                          </Properties>
-                          <Events>
-                            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="NextWeeksbtnActionPerformed"/>
-                          </Events>
                         </Component>
                       </SubComponents>
                     </Container>

--- a/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.form
+++ b/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.form
@@ -165,7 +165,7 @@
                     <DimensionLayout dim="1">
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Group type="102" alignment="0" attributes="0">
-                              <Component id="dailyChartPanel" pref="467" max="32767" attributes="0"/>
+                              <Component id="dailyChartPanel" pref="475" max="32767" attributes="0"/>
                               <EmptySpace min="-2" pref="27" max="-2" attributes="0"/>
                               <Component id="DailyTitlePanel" min="-2" max="-2" attributes="0"/>
                               <EmptySpace type="separate" max="-2" attributes="0"/>
@@ -194,7 +194,7 @@
 
                       <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
                       <SubComponents>
-                        <Component class="javax.swing.JLabel" name="DailyTitle">
+                        <Component class="javax.swing.JLabel" name="dailyTitle">
                           <Properties>
                             <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                               <Font name="Segoe UI Semibold" size="18" style="1"/>
@@ -206,7 +206,7 @@
                     </Container>
                     <Container class="javax.swing.JPanel" name="NextDaysPanel">
 
-                      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+                      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout"/>
                       <SubComponents>
                         <Component class="javax.swing.JButton" name="PreviousDaybtn">
                           <Properties>
@@ -226,6 +226,9 @@
                             </Property>
                             <Property name="text" type="java.lang.String" value="Next Day"/>
                           </Properties>
+                          <Events>
+                            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="NextDaybtnActionPerformed"/>
+                          </Events>
                         </Component>
                       </SubComponents>
                     </Container>

--- a/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.form
+++ b/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.form
@@ -210,7 +210,7 @@
                             <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                               <Font name="Segoe UI" size="12" style="1"/>
                             </Property>
-                            <Property name="text" type="java.lang.String" value="Previous Weeks"/>
+                            <Property name="text" type="java.lang.String" value="Previous Week"/>
                           </Properties>
                           <Events>
                             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="PreviousWeeksbtnActionPerformed"/>
@@ -221,7 +221,7 @@
                             <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                               <Font name="Segoe UI" size="12" style="1"/>
                             </Property>
-                            <Property name="text" type="java.lang.String" value="Next Weeks"/>
+                            <Property name="text" type="java.lang.String" value="Next Week"/>
                           </Properties>
                           <Events>
                             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="NextWeeksbtnActionPerformed"/>

--- a/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.java
+++ b/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.java
@@ -194,7 +194,7 @@ public class Dashboard extends javax.swing.JFrame {
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
-        // TabbedPane.addTab("Daily", DailyPanel);
+        TabbedPane.addTab("Daily", DailyPanel);
 
         WeeklyPanel.setLayout(new javax.swing.BoxLayout(WeeklyPanel, javax.swing.BoxLayout.Y_AXIS));
 
@@ -211,7 +211,7 @@ public class Dashboard extends javax.swing.JFrame {
         WeeklyPanel.add(WeeksTitlePanel);
 
         PreviousWeeksbtn.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
-        PreviousWeeksbtn.setText("Previous Weeks");
+        PreviousWeeksbtn.setText("Previous Week");
         PreviousWeeksbtn.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 PreviousWeeksbtnActionPerformed(evt);
@@ -220,7 +220,7 @@ public class Dashboard extends javax.swing.JFrame {
         ActionButtonPanel.add(PreviousWeeksbtn);
 
         NextWeeksbtn.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
-        NextWeeksbtn.setText("Next Weeks");
+        NextWeeksbtn.setText("Next Week");
         NextWeeksbtn.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 NextWeeksbtnActionPerformed(evt);
@@ -231,7 +231,6 @@ public class Dashboard extends javax.swing.JFrame {
         WeeklyPanel.add(ActionButtonPanel);
 
         TabbedPane.addTab("Weekly", WeeklyPanel);
-				TabbedPane.addTab("Daily", DailyPanel);
 
         ActivityPanel.setLayout(new javax.swing.BoxLayout(ActivityPanel, javax.swing.BoxLayout.LINE_AXIS));
 

--- a/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.java
+++ b/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.java
@@ -45,13 +45,13 @@ public class Dashboard extends javax.swing.JFrame {
         this.dBInstance = dBInstance;
         initComponents();
         additionalInitComponents();
-        chartSetup(false);
+        chartSetup(false, true);
         updateTable();
     }
     
     public void onActivityFormClosed(boolean status) {
         if(status) {
-            chartSetup(true);
+            chartSetup(true, true);
             updateTable();
         }
     }
@@ -104,6 +104,7 @@ public class Dashboard extends javax.swing.JFrame {
         var endWeek = week.get(6).toString();
 
         weeksLabel.setText(startWeek + " - " + endWeek);
+        dailyTitle.setText(selectedDate.toString());
     }    
     
     /**
@@ -128,7 +129,7 @@ public class Dashboard extends javax.swing.JFrame {
         DailyPanel = new javax.swing.JPanel();
         dailyChartPanel = new javax.swing.JPanel();
         DailyTitlePanel = new javax.swing.JPanel();
-        DailyTitle = new javax.swing.JLabel();
+        dailyTitle = new javax.swing.JLabel();
         NextDaysPanel = new javax.swing.JPanel();
         PreviousDaybtn = new javax.swing.JButton();
         NextDaybtn = new javax.swing.JButton();
@@ -186,9 +187,11 @@ public class Dashboard extends javax.swing.JFrame {
         dailyChartPanel.setBorder(new javax.swing.border.SoftBevelBorder(javax.swing.border.BevelBorder.RAISED));
         dailyChartPanel.setLayout(new java.awt.BorderLayout(10, 10));
 
-        DailyTitle.setFont(new java.awt.Font("Segoe UI Semibold", 1, 18)); // NOI18N
-        DailyTitle.setText("7 March");
-        DailyTitlePanel.add(DailyTitle);
+        dailyTitle.setFont(new java.awt.Font("Segoe UI Semibold", 1, 18)); // NOI18N
+        dailyTitle.setText("7 March");
+        DailyTitlePanel.add(dailyTitle);
+
+        NextDaysPanel.setLayout(new javax.swing.BoxLayout(NextDaysPanel, javax.swing.BoxLayout.LINE_AXIS));
 
         PreviousDaybtn.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
         PreviousDaybtn.setText("Previous Day");
@@ -201,6 +204,11 @@ public class Dashboard extends javax.swing.JFrame {
 
         NextDaybtn.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
         NextDaybtn.setText("Next Day");
+        NextDaybtn.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                NextDaybtnActionPerformed(evt);
+            }
+        });
         NextDaysPanel.add(NextDaybtn);
 
         javax.swing.GroupLayout DailyPanelLayout = new javax.swing.GroupLayout(DailyPanel);
@@ -220,7 +228,7 @@ public class Dashboard extends javax.swing.JFrame {
         DailyPanelLayout.setVerticalGroup(
             DailyPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(DailyPanelLayout.createSequentialGroup()
-                .addComponent(dailyChartPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 467, Short.MAX_VALUE)
+                .addComponent(dailyChartPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 475, Short.MAX_VALUE)
                 .addGap(27, 27, 27)
                 .addComponent(DailyTitlePanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addGap(18, 18, 18)
@@ -362,20 +370,23 @@ public class Dashboard extends javax.swing.JFrame {
     private void NextWeeksbtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_NextWeeksbtnActionPerformed
         // TODO add your handling code here:
         this.selectedDate = DateHelper.getMondayFromNextWeek(selectedDate);
-        chartSetup(true);
+        chartSetup(true, true);
         updateTable();
     }//GEN-LAST:event_NextWeeksbtnActionPerformed
 
     private void PreviousWeeksbtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_PreviousWeeksbtnActionPerformed
         // TODO add your handling code here:
         this.selectedDate = DateHelper.getSundayFromPreviousWeek(selectedDate);
-        chartSetup(true);
+        chartSetup(true, true);
         updateTable();
     }//GEN-LAST:event_PreviousWeeksbtnActionPerformed
 
     
     private void PreviousDaybtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_PreviousDaybtnActionPerformed
         // TODO add your handling code here:
+        this.selectedDate = this.selectedDate.minusDays(1);
+        chartSetup(true, true);
+        updateTable();
     }//GEN-LAST:event_PreviousDaybtnActionPerformed
 
     private void AddNewActivitybtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_AddNewActivitybtnActionPerformed
@@ -402,21 +413,30 @@ public class Dashboard extends javax.swing.JFrame {
             
             if(isSuccessful) {
                 JOptionPane.showMessageDialog(this, "Successfully deleted the activity", "Status Dialog", JOptionPane.INFORMATION_MESSAGE);
-                chartSetup(true);
+                chartSetup(true, true);
                 updateTable();
             } else {
                 JOptionPane.showMessageDialog(this, "Failed to deleted the activity", "Status Dialog", JOptionPane.ERROR_MESSAGE);
             }
         }
     }//GEN-LAST:event_deleteActivityBtnActionPerformed
+
+    private void NextDaybtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_NextDaybtnActionPerformed
+        // TODO add your handling code here:
+        this.selectedDate = this.selectedDate.plusDays(1);
+        chartSetup(true, true);
+        updateTable();
+    }//GEN-LAST:event_NextDaybtnActionPerformed
     
     
     private void getActivitiesWeek(LocalDate currentDate) {
         activities = this.dBInstance.getActivitiesAWeek(currentDate);
     }
     
-    private void chartSetup(boolean isUpdate) {
-        this.getActivitiesWeek(selectedDate);
+    private void chartSetup(boolean isUpdate, boolean isDoRefetch) {
+        if(isDoRefetch) {
+            this.getActivitiesWeek(selectedDate);
+        }
         
         DefaultPieDataset weeklyDataset = DatasetFactory.weeklyChartDataset(activities);
         DefaultCategoryDataset dailyDataset = DatasetFactory.dailyChartDataset(activities, selectedDate);
@@ -486,6 +506,7 @@ public class Dashboard extends javax.swing.JFrame {
                     
                 } catch (SQLException ex) {
                     Logger.getLogger(Dashboard.class.getName()).log(Level.SEVERE, null, ex);
+                    System.exit(1);
                 }
             }
         });
@@ -498,7 +519,6 @@ public class Dashboard extends javax.swing.JFrame {
     private javax.swing.JPanel ActivityTable;
     private javax.swing.JButton AddNewActivitybtn;
     private javax.swing.JPanel DailyPanel;
-    private javax.swing.JLabel DailyTitle;
     private javax.swing.JPanel DailyTitlePanel;
     private javax.swing.JPanel DashboardPanel;
     private javax.swing.JPanel MainPanel;
@@ -511,6 +531,7 @@ public class Dashboard extends javax.swing.JFrame {
     private javax.swing.JPanel WeeklyPanel;
     private javax.swing.JPanel WeeksTitlePanel;
     private javax.swing.JPanel dailyChartPanel;
+    private javax.swing.JLabel dailyTitle;
     private javax.swing.JButton deleteActivityBtn;
     private javax.swing.JButton editActivitybtn;
     private javax.swing.JLabel jLabel1;

--- a/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.java
+++ b/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.java
@@ -80,32 +80,30 @@ public class Dashboard extends javax.swing.JFrame {
         DefaultTableModel model = (DefaultTableModel) jTable1.getModel();
         model.setRowCount(0);
         
-        if(activities.length > 0) {
-            for(int i = 0; i < activities.length; i++) {
-             // Construct specific type if additionalOption is not null
-                Activity activity = activities[i];
-                String specificCategory = activity.specificCategory();
-                String metric = "";
+        for(int i = 0; i < activities.length; i++) {
+         // Construct specific type if additionalOption is not null
+            Activity activity = activities[i];
+            String specificCategory = activity.specificCategory();
+            String metric = "";
 
-                if(activity.category().contains("Transportation")) {
-                    metric = " (km)";
-                } else if (activity.specificCategory().contains("LPG")) {
-                    metric = " (seconds)";
-                } else {
-                    metric = " (kWh)";
-                }
-
-                Object[] rowData = {activity.category(), activity.subCategory(), specificCategory, activity.calcMetric() + metric, activity.emissionTotal()};
-
-                model.addRow(rowData);
+            if(activity.category().contains("Transportation")) {
+                metric = " (km)";
+            } else if (activity.specificCategory().contains("LPG")) {
+                metric = " (seconds)";
+            } else {
+                metric = " (kWh)";
             }
-        
-        
-            var startWeek = activities[0].dateCreated().toString();
-            var endWeek = activities[activities.length-1].dateCreated().toString();
 
-            weeksLabel.setText(startWeek + " - " + endWeek);
+            Object[] rowData = {activity.category(), activity.subCategory(), specificCategory, activity.calcMetric() + metric, activity.emissionTotal()};
+
+            model.addRow(rowData);
         }
+
+        var week = DateHelper.getDaysOfWeek(selectedDate);
+        var startWeek = week.get(0).toString();
+        var endWeek = week.get(6).toString();
+
+        weeksLabel.setText(startWeek + " - " + endWeek);
     }    
     
     /**
@@ -120,13 +118,6 @@ public class Dashboard extends javax.swing.JFrame {
         MainPanel = new javax.swing.JPanel();
         DashboardPanel = new javax.swing.JPanel();
         TabbedPane = new javax.swing.JTabbedPane();
-        DailyPanel = new javax.swing.JPanel();
-        dailyChartPanel = new javax.swing.JPanel();
-        DailyTitlePanel = new javax.swing.JPanel();
-        DailyTitle = new javax.swing.JLabel();
-        NextDaysPanel = new javax.swing.JPanel();
-        PreviousDaybtn = new javax.swing.JButton();
-        NextDaybtn = new javax.swing.JButton();
         WeeklyPanel = new javax.swing.JPanel();
         weeklyChartPanel = new javax.swing.JPanel();
         WeeksTitlePanel = new javax.swing.JPanel();
@@ -134,6 +125,13 @@ public class Dashboard extends javax.swing.JFrame {
         ActionButtonPanel = new javax.swing.JPanel();
         PreviousWeeksbtn = new javax.swing.JButton();
         NextWeeksbtn = new javax.swing.JButton();
+        DailyPanel = new javax.swing.JPanel();
+        dailyChartPanel = new javax.swing.JPanel();
+        DailyTitlePanel = new javax.swing.JPanel();
+        DailyTitle = new javax.swing.JLabel();
+        NextDaysPanel = new javax.swing.JPanel();
+        PreviousDaybtn = new javax.swing.JButton();
+        NextDaybtn = new javax.swing.JButton();
         ActivityPanel = new javax.swing.JPanel();
         ActivityTable = new javax.swing.JPanel();
         jLabel1 = new javax.swing.JLabel();
@@ -148,6 +146,42 @@ public class Dashboard extends javax.swing.JFrame {
         getContentPane().setLayout(new javax.swing.BoxLayout(getContentPane(), javax.swing.BoxLayout.LINE_AXIS));
 
         MainPanel.setLayout(new javax.swing.BoxLayout(MainPanel, javax.swing.BoxLayout.LINE_AXIS));
+
+        WeeklyPanel.setLayout(new javax.swing.BoxLayout(WeeklyPanel, javax.swing.BoxLayout.Y_AXIS));
+
+        weeklyChartPanel.setBorder(new javax.swing.border.SoftBevelBorder(javax.swing.border.BevelBorder.RAISED));
+        weeklyChartPanel.setLayout(new java.awt.BorderLayout(10, 10));
+        WeeklyPanel.add(weeklyChartPanel);
+
+        WeeksTitlePanel.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
+
+        weeksLabel.setFont(new java.awt.Font("Segoe UI Semibold", 1, 18)); // NOI18N
+        weeksLabel.setText("7 March - 14 March");
+        WeeksTitlePanel.add(weeksLabel);
+
+        WeeklyPanel.add(WeeksTitlePanel);
+
+        PreviousWeeksbtn.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
+        PreviousWeeksbtn.setText("Previous Week");
+        PreviousWeeksbtn.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                PreviousWeeksbtnActionPerformed(evt);
+            }
+        });
+        ActionButtonPanel.add(PreviousWeeksbtn);
+
+        NextWeeksbtn.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
+        NextWeeksbtn.setText("Next Week");
+        NextWeeksbtn.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                NextWeeksbtnActionPerformed(evt);
+            }
+        });
+        ActionButtonPanel.add(NextWeeksbtn);
+
+        WeeklyPanel.add(ActionButtonPanel);
+
+        TabbedPane.addTab("Weekly", WeeklyPanel);
 
         dailyChartPanel.setBorder(new javax.swing.border.SoftBevelBorder(javax.swing.border.BevelBorder.RAISED));
         dailyChartPanel.setLayout(new java.awt.BorderLayout(10, 10));
@@ -195,42 +229,6 @@ public class Dashboard extends javax.swing.JFrame {
         );
 
         TabbedPane.addTab("Daily", DailyPanel);
-
-        WeeklyPanel.setLayout(new javax.swing.BoxLayout(WeeklyPanel, javax.swing.BoxLayout.Y_AXIS));
-
-        weeklyChartPanel.setBorder(new javax.swing.border.SoftBevelBorder(javax.swing.border.BevelBorder.RAISED));
-        weeklyChartPanel.setLayout(new java.awt.BorderLayout(10, 10));
-        WeeklyPanel.add(weeklyChartPanel);
-
-        WeeksTitlePanel.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
-
-        weeksLabel.setFont(new java.awt.Font("Segoe UI Semibold", 1, 18)); // NOI18N
-        weeksLabel.setText("7 March - 14 March");
-        WeeksTitlePanel.add(weeksLabel);
-
-        WeeklyPanel.add(WeeksTitlePanel);
-
-        PreviousWeeksbtn.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
-        PreviousWeeksbtn.setText("Previous Week");
-        PreviousWeeksbtn.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                PreviousWeeksbtnActionPerformed(evt);
-            }
-        });
-        ActionButtonPanel.add(PreviousWeeksbtn);
-
-        NextWeeksbtn.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
-        NextWeeksbtn.setText("Next Week");
-        NextWeeksbtn.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                NextWeeksbtnActionPerformed(evt);
-            }
-        });
-        ActionButtonPanel.add(NextWeeksbtn);
-
-        WeeklyPanel.add(ActionButtonPanel);
-
-        TabbedPane.addTab("Weekly", WeeklyPanel);
 
         ActivityPanel.setLayout(new javax.swing.BoxLayout(ActivityPanel, javax.swing.BoxLayout.LINE_AXIS));
 
@@ -363,10 +361,16 @@ public class Dashboard extends javax.swing.JFrame {
 
     private void NextWeeksbtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_NextWeeksbtnActionPerformed
         // TODO add your handling code here:
+        this.selectedDate = DateHelper.getMondayFromNextWeek(selectedDate);
+        chartSetup(true);
+        updateTable();
     }//GEN-LAST:event_NextWeeksbtnActionPerformed
 
     private void PreviousWeeksbtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_PreviousWeeksbtnActionPerformed
         // TODO add your handling code here:
+        this.selectedDate = DateHelper.getSundayFromPreviousWeek(selectedDate);
+        chartSetup(true);
+        updateTable();
     }//GEN-LAST:event_PreviousWeeksbtnActionPerformed
 
     

--- a/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.java
+++ b/app/src/main/java/edu/group3/ecofriendlytracker/Dashboard.java
@@ -194,7 +194,7 @@ public class Dashboard extends javax.swing.JFrame {
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
-        TabbedPane.addTab("Daily", DailyPanel);
+        // TabbedPane.addTab("Daily", DailyPanel);
 
         WeeklyPanel.setLayout(new javax.swing.BoxLayout(WeeklyPanel, javax.swing.BoxLayout.Y_AXIS));
 
@@ -231,6 +231,7 @@ public class Dashboard extends javax.swing.JFrame {
         WeeklyPanel.add(ActionButtonPanel);
 
         TabbedPane.addTab("Weekly", WeeklyPanel);
+				TabbedPane.addTab("Daily", DailyPanel);
 
         ActivityPanel.setLayout(new javax.swing.BoxLayout(ActivityPanel, javax.swing.BoxLayout.LINE_AXIS));
 

--- a/app/src/main/java/edu/group3/ecofriendlytracker/DatabasesConnection.java
+++ b/app/src/main/java/edu/group3/ecofriendlytracker/DatabasesConnection.java
@@ -33,16 +33,7 @@ public class DatabasesConnection {
     public Activity[] getActivitiesAWeek(LocalDate date) {
         // Get week range from date
         Activity[] activities = null;
-        List<LocalDate> week = new ArrayList<>();
-        DayOfWeek dayOfWeek = date.getDayOfWeek();
-        
-        int daysToMonday = (dayOfWeek.getValue() - DayOfWeek.MONDAY.getValue() + 7) % 7;
-        
-        LocalDate monday = date.minusDays(daysToMonday);
-        
-        for (int i = 0; i < 7; i++) {
-            week.add(monday.plusDays(i));
-        }
+        List<LocalDate> week = DateHelper.getDaysOfWeek(date);
              
         String startDate = week.get(0).toString();
         String endDate = week.get(6).toString();

--- a/app/src/main/java/edu/group3/ecofriendlytracker/DateHelper.java
+++ b/app/src/main/java/edu/group3/ecofriendlytracker/DateHelper.java
@@ -1,0 +1,27 @@
+package edu.group3.ecofriendlytracker;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * @author altaf
+ */
+public class DateHelper {
+    public static List<LocalDate> getDaysOfWeek(LocalDate date) {
+        List<LocalDate> week = new ArrayList<>();
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+        
+        int daysToMonday = (dayOfWeek.getValue() - DayOfWeek.MONDAY.getValue() + 7) % 7;
+        
+        LocalDate monday = date.minusDays(daysToMonday);
+        
+        for (int i = 0; i < 7; i++) {
+            week.add(monday.plusDays(i));
+        }
+        
+        return week;
+    }
+}

--- a/app/src/main/java/edu/group3/ecofriendlytracker/DateHelper.java
+++ b/app/src/main/java/edu/group3/ecofriendlytracker/DateHelper.java
@@ -24,4 +24,28 @@ public class DateHelper {
         
         return week;
     }
+    
+    public static LocalDate getSundayFromPreviousWeek(LocalDate date) {
+        // Return sunday of the previous week
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+        // Check if date is sunday
+        if(dayOfWeek.getValue() == DayOfWeek.SUNDAY.getValue()) {
+            return date.minusDays(7);
+        }
+        
+        int daysToMonday = (dayOfWeek.getValue() - DayOfWeek.MONDAY.getValue() + 7) % 7;        
+        return date.minusDays(daysToMonday + 1);
+    }
+    
+    public static LocalDate getMondayFromNextWeek(LocalDate date) {
+        // Return monday of the next week
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+        // Check if date is monday
+        if(dayOfWeek.getValue() == DayOfWeek.MONDAY.getValue()) {
+            return date.plusDays(7);
+        }
+        
+        int daysToMonday = (DayOfWeek.MONDAY.getValue() - dayOfWeek.getValue() + 7) % 7;
+        return date.plusDays(daysToMonday);
+    }
 }


### PR DESCRIPTION
- Move date manipulation related stuff into DateHelper static methods.
- Make weekly panel as the first tab to show, this is because the table shows the whole week.
- Add daily emission total navigation (next day, previous day)
- Add weekly emission total navigation (next week, previous week)